### PR TITLE
Add book parts and PDF render workflow

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -1,0 +1,35 @@
+name: Render book
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  render:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Quarto
+        uses: quarto-dev/quarto-actions/setup@v2
+        with:
+          tinytex: true
+
+      - name: Render book
+        uses: quarto-dev/quarto-actions/render@v2
+
+      - name: Upload PDF
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-of-imagery-pdf
+          path: _book/Book-of-Imagery.pdf
+          if-no-files-found: error
+
+      - name: Upload rendered book
+        uses: actions/upload-artifact@v4
+        with:
+          name: book-of-imagery-site
+          path: _book
+          if-no-files-found: error

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,16 +20,20 @@ book:
   repo-url: https://github.com/Imago-SDRUK/book-of-imagery
   repo-branch: main
   repo-actions: [edit, issue]
+  downloads: [pdf]
 
   chapters:
     - index.qmd
-    - chapters/intro.qmd
-    - chapters/image-data.qmd
-    - chapters/clive.qmd
-    - chapters/psf.qmd
-    - chapters/rgb.qmd
-    # - chapters/synthesis.qmd
-    # - chapters/way-forward.qmd
+    - part: "Foundations"
+      chapters:
+        - chapters/intro.qmd
+        - chapters/image-data.qmd
+    - part: "Data products"
+      chapters:
+        - chapters/clive.qmd
+        - chapters/psf.qmd
+        - chapters/rgb.qmd
+    - part: "Social research and policy application"
     - chapters/references.qmd
 
 bibliography: references.bib
@@ -58,6 +62,13 @@ format:
         </script>
   pdf:
     documentclass: scrreprt
+    papersize: a4
+    pdf-engine: xelatex
+    toc: true
+    number-sections: true
+    number-depth: 3
+    colorlinks: true
+    include-in-header: style/pdf-preamble.tex
+    include-before-body: style/pdf-before-body.tex
 
 editor: visual
-

--- a/style/pdf-before-body.tex
+++ b/style/pdf-before-body.tex
@@ -1,0 +1,65 @@
+% Custom front matter for the PDF edition.
+\pagestyle{empty}
+
+\begin{titlepage}
+\thispagestyle{empty}
+\centering
+\vspace*{0.12\paperheight}
+
+\includegraphics[width=0.42\textwidth]{assets/Imago-logo.png}
+
+\vspace{2.2cm}
+
+{\Huge\bfseries Book of Imagery\par}
+
+\vspace{0.7cm}
+
+{\Large Translating imagery into meaningful social and policy measures\par}
+
+\vspace{1.4cm}
+
+{\large Version 0.1\par}
+
+\vfill
+
+{\large Imago - Data Service for Imagery\par}
+{\large 2025\par}
+
+\end{titlepage}
+
+\clearpage
+
+\hspace{0pt}
+\vfill
+
+\noindent \copyright{} 2025 The authors
+
+\bigskip
+
+\noindent Publisher: Imago - Data Service for Imagery.
+
+\medskip
+
+\noindent Except where otherwise noted, this work is licensed under a Creative Commons Attribution 4.0 International Licence (CC BY 4.0).
+
+\medskip
+
+\noindent DOI: \url{https://doi.org/10.5281/zenodo.17976055}
+
+\medskip
+
+\noindent Suggested citation:
+
+\medskip
+
+\noindent Rowe, F., Mahabir, R., Butters, O., Almarzouq, B., Arribas-Bel, D., Chen, F., Elsey, J., Franklin, R., Guzman Perez, A., Kingston, R., Kryukov, V., Patranabis, S., Pardy, M., Peppa, M., Pietrostefani, E., Radoux, E., Rodgers, S., Valipour Shokouhi, B., and Watson, P. (2025). \textit{The Book of Imagery: Translating imagery into meaningful social and policy measures}. Version 0.1. Imago - Data Service for Imagery. \url{https://doi.org/10.5281/zenodo.17976055}. \url{https://www.boi.imago.ac.uk/}
+
+\medskip
+
+\noindent Digital material and resources associated with this book are available at \url{https://www.boi.imago.ac.uk/}
+
+\vfill
+\hspace{0pt}
+\clearpage
+
+\pagestyle{plain}

--- a/style/pdf-preamble.tex
+++ b/style/pdf-preamble.tex
@@ -1,0 +1,26 @@
+% PDF book styling adapted from the UN-CEBD Mobile Phone Data Handbook.
+\usepackage{fontspec}
+\setmainfont[
+  Extension = .otf,
+  UprightFont = *-regular,
+  BoldFont = *-bold,
+  ItalicFont = *-italic,
+  BoldItalicFont = *-bolditalic
+]{texgyrepagella}
+
+\AtBeginDocument{\let\maketitle\relax}
+
+\usepackage{eso-pic}
+
+\usepackage{float}
+\floatplacement{figure}{!htb}
+\floatplacement{table}{!htb}
+
+\usepackage{caption}
+\captionsetup{labelfont=bf}
+
+\makeatletter
+\@beginparpenalty=10000
+\makeatother
+
+\raggedbottom


### PR DESCRIPTION
Closes #29
Closes #30

## Summary
- Organises the book into Quarto parts.
- Adds PDF download support and PDF styling.
- Adds a GitHub Actions render workflow for HTML/PDF outputs.

## Validation
- quarto render